### PR TITLE
adds 'or' operator as a failsafe in warning.rb if warning_hash doesn't have a ruleId

### DIFF
--- a/lib/eslint-rails/warning.rb
+++ b/lib/eslint-rails/warning.rb
@@ -6,7 +6,7 @@ module ESLintRails
     private_constant :SEVERITY
 
     def initialize(warning_hash)
-      @rule_id = warning_hash['ruleId']
+      @rule_id = warning_hash['ruleId'] || "unexpected error"
       @severity = warning_hash['severity']
       @message = warning_hash['message']
       @line = warning_hash['line']


### PR DESCRIPTION
This is a suggested PR for issue #11.

This provides a more user-friendly error and allows the linter to finish in stead of blowing up.