### PR TITLE
Set `therubyracer` as a development dependency

### DIFF
--- a/eslint-rails.gemspec
+++ b/eslint-rails.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'railties', '>= 3.2'
-  spec.add_dependency 'therubyracer'
   spec.add_dependency 'execjs'
   spec.add_dependency 'colorize'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'therubyracer'
 end


### PR DESCRIPTION
Execjs should handle the presence of a Javascript runtime, whether it's Node, therubyracer, or something else. Specifically requiring this dependency unnecessarily makes this gem heavier