### PR TITLE
Lint all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,18 @@ in your browser. To force retrieval of the default conguration, use
 
 ![rake-eslint-rails-run][]
 
+This will analyze all of the javascript files in the project:
 ```sh
 rake eslint:run
 ```
 
-This will analyze `application.js`. Optionally, you can supply a filename to the
-task. To analyze `components/woop.js` and `utilities.js.coffee.erb` you would
-run (respectively):
+Optionally, you can supply a filename to the task. To analyze `app/assets/javascripts/components/utilities.js`, you can run any of the following:
 
 ```sh
-rake eslint:run[components/woop]
-rake eslint:run[utilities]
+rake eslint:run[components/utilities]
+rake eslint:run[components/utilities.js]
+rake eslint:run[app/assets/javascripts/components/utilities]
+rake eslint:run[app/assets/javascripts/components/utilities.js]
 ```
 
 ### Web interface

--- a/README.md
+++ b/README.md
@@ -37,11 +37,18 @@ in your browser. To force retrieval of the default conguration, use
 ![rake-eslint-rails-run][]
 
 This will analyze all of the javascript files in the project:
+
+```sh
+rake eslint:run_all
+```
+
+Or you can run it on a single file. This will analyze `application.js`:
+
 ```sh
 rake eslint:run
 ```
 
-Optionally, you can supply a filename to the task. To analyze `app/assets/javascripts/components/utilities.js`, you can run any of the following:
+Or, you can supply a filename to the task, using several different formats, and it will lint just that file. For example, to analyze `app/assets/javascripts/components/utilities.js`, you can run any of the following:
 
 ```sh
 rake eslint:run[components/utilities]

--- a/lib/eslint-rails/runner.rb
+++ b/lib/eslint-rails/runner.rb
@@ -7,7 +7,9 @@ module ESLintRails
     end
 
     def run
-      file_content = Rails.application.assets[@filename].to_s
+      asset = Rails.application.assets[@filename]
+      relative_path = asset.pathname.relative_path_from(Pathname.new(Dir.pwd))
+      file_content = asset.to_s
 
       eslint_js = Rails.application.assets['eslint'].to_s
 
@@ -18,7 +20,7 @@ module ESLintRails
           return eslint.verify('#{escape_javascript file_content}', #{Config.read});
         }()
       JS
-      warning_hashes.map{|hash| ESLintRails::Warning.new(hash)}
+      warning_hashes.map{|hash| ESLintRails::Warning.new(relative_path, hash)}
     end
   end
 end

--- a/lib/eslint-rails/runner.rb
+++ b/lib/eslint-rails/runner.rb
@@ -9,6 +9,18 @@ module ESLintRails
     end
 
     def run
+      warnings = assets.map do |asset|
+        generate_warnings(asset).tap { |warnings| output_progress(warnings) }
+      end
+      
+      puts
+      
+      warnings.flatten
+    end
+    
+    private
+    
+    def assets
       all_assets = Rails.application.assets
 
       assets = case @filename
@@ -17,37 +29,45 @@ module ESLintRails
                else
                  [all_assets[@filename]]
                end
-
       assets.reject!{|a| a.to_s =~ /eslint.js|vendor|gems|min.js|editorial/ }
-
-      eslint_js = Rails.application.assets['eslint'].to_s
-
-      assets.map do |asset|
-        relative_path = asset.relative_path_from(Pathname.new(Dir.pwd))
-        file_content = asset.read
-
-        warning_hashes = ExecJS.eval <<-JS
-          function () {
-            window = this;
-            #{eslint_js};
-            return eslint.verify('#{escape_javascript file_content}', #{Config.read});
-          }()
-        JS
-        warnings = warning_hashes.map{|hash| ESLintRails::Warning.new(relative_path, hash)}
-
-        file_severity = warnings.map(&:severity).uniq.sort.first
-
-        print case file_severity
-              when :high
-                'H'.red
-              when :low
-                'L'.yellow
-              else
-                '.'.green
-              end
-
-        warnings
-      end.flatten
+    end
+    
+    def eslint_js
+      @eslint_js ||= Rails.application.assets['eslint'].to_s
+    end
+    
+    def warning_hashes(file_content)
+      ExecJS.eval <<-JS
+        function () {
+          window = this;
+          #{eslint_js};
+          return eslint.verify('#{escape_javascript(file_content)}', #{Config.read});
+        }()
+      JS
+    end
+    
+    def generate_warnings(asset)
+      relative_path = asset.relative_path_from(Pathname.new(Dir.pwd))
+      file_content = asset.read
+      
+      warning_hashes(file_content).map do |hash|
+        ESLintRails::Warning.new(relative_path, hash)
+      end
+    end
+    
+    def output_progress(warnings)
+      print case file_severity(warnings)
+            when :high
+              'H'.red
+            when :low
+              'L'.yellow
+            else
+              '.'.green
+            end
+    end
+    
+    def file_severity(warnings)
+      warnings.map(&:severity).uniq.sort.first
     end
   end
 end

--- a/lib/eslint-rails/runner.rb
+++ b/lib/eslint-rails/runner.rb
@@ -1,26 +1,53 @@
+require 'colorize'
+
 module ESLintRails
   class Runner
     include ActionView::Helpers::JavaScriptHelper
 
     def initialize(filename)
-      @filename = filename || 'application'
+      @filename = filename || 'all'
     end
 
     def run
-      asset = Rails.application.assets[@filename]
-      relative_path = asset.pathname.relative_path_from(Pathname.new(Dir.pwd))
-      file_content = asset.to_s
+      all_assets = Rails.application.assets
+
+      assets = case @filename
+               when 'all'
+                 all_assets.each_file.to_a.select { |pn| pn.extname == '.js' }
+               else
+                 [all_assets[@filename]]
+               end
+
+      assets.reject!{|a| a.to_s =~ /eslint.js|vendor|gems|min.js|editorial/ }
 
       eslint_js = Rails.application.assets['eslint'].to_s
 
-      warning_hashes = ExecJS.eval <<-JS
-        function () {
-          window = this;
-          #{eslint_js};
-          return eslint.verify('#{escape_javascript file_content}', #{Config.read});
-        }()
-      JS
-      warning_hashes.map{|hash| ESLintRails::Warning.new(relative_path, hash)}
+      assets.map do |asset|
+        relative_path = asset.relative_path_from(Pathname.new(Dir.pwd))
+        file_content = asset.read
+
+        warning_hashes = ExecJS.eval <<-JS
+          function () {
+            window = this;
+            #{eslint_js};
+            return eslint.verify('#{escape_javascript file_content}', #{Config.read});
+          }()
+        JS
+        warnings = warning_hashes.map{|hash| ESLintRails::Warning.new(relative_path, hash)}
+
+        file_severity = warnings.map(&:severity).uniq.sort.first
+
+        print case file_severity
+              when :high
+                'H'.red
+              when :low
+                'L'.yellow
+              else
+                '.'.green
+              end
+
+        warnings
+      end.flatten
     end
   end
 end

--- a/lib/eslint-rails/text_formatter.rb
+++ b/lib/eslint-rails/text_formatter.rb
@@ -4,21 +4,17 @@ require 'colorize'
 module ESLintRails
   class TextFormatter
 
-    WARNING_TEMPLATE = <<-TEXT.strip_heredoc
-      <%= line %>,<%= column %> <%= severity %>! [<%= rule_id %>] <%= message %>
-    TEXT
-
     def initialize(warnings)
       @warnings = warnings
     end
 
     def format
-      max_line_column_length = @warnings.map { |warning| (warning.line + warning.column).size }.max
+      max_line_column_length = @warnings.map { |warning| warning.location.size }.max
       max_rule_id_length = @warnings.map { |warning| warning.rule_id.size }.max
       max_message_length = @warnings.map { |warning| warning.message.size }.max
       @warnings.each do |warning|
         message = [
-          "#{warning.line}:#{warning.column}".ljust(max_line_column_length + 1),
+          warning.location.ljust(max_line_column_length + 1),
           warning.severity.to_s.ljust(6),
           warning.rule_id.ljust(max_rule_id_length),
           warning.message.ljust(max_message_length)

--- a/lib/eslint-rails/warning.rb
+++ b/lib/eslint-rails/warning.rb
@@ -1,11 +1,12 @@
 module ESLintRails
   class Warning
-    attr_reader :rule_id, :message, :line, :column, :node_type
+    attr_reader :filename, :rule_id, :message, :line, :column, :node_type
 
     SEVERITY = [ :low, :high ].freeze
     private_constant :SEVERITY
 
-    def initialize(warning_hash)
+    def initialize(filename, warning_hash)
+      @filename = filename
       @rule_id = warning_hash['ruleId'] || "unexpected error"
       @severity = warning_hash['severity']
       @message = warning_hash['message']
@@ -16,6 +17,10 @@ module ESLintRails
 
     def severity
       SEVERITY[@severity-1]
+    end
+
+    def location
+      "#{filename}:#{line}:#{column}"
     end
   end
 end

--- a/lib/tasks/eslint.rake
+++ b/lib/tasks/eslint.rake
@@ -7,6 +7,7 @@ namespace :eslint do
   desc %{Run ESLint against the specified JavaScript file and report warnings (default is 'application')}
   task :run, [:filename] => :environment do |_, args|
     warnings = ESLintRails::Runner.new(args[:filename]).run
+    puts
 
     if warnings.empty?
       puts 'All good! :)'.green

--- a/lib/tasks/eslint.rake
+++ b/lib/tasks/eslint.rake
@@ -3,11 +3,8 @@ ENV['EXECJS_RUNTIME'] = 'RubyRacer'
 require 'eslint-rails'
 
 namespace :eslint do
-
-  desc %{Run ESLint against the specified JavaScript file and report warnings (default is 'application')}
-  task :run, [:filename] => :environment do |_, args|
-    warnings = ESLintRails::Runner.new(args[:filename]).run
-    puts
+  def run_and_print_results(file)
+    warnings = ESLintRails::Runner.new(file).run
 
     if warnings.empty?
       puts 'All good! :)'.green
@@ -17,6 +14,15 @@ namespace :eslint do
       formatter.format
       exit 1
     end
+  end
+
+  desc %{Run ESLint against the specified JavaScript file and report warnings (default is 'application')}
+  task :run, [:filename] => :environment do |_, args|
+    run_and_print_results(args[:filename] || 'application')
+  end
+
+  task run_all: :environment do |_, args|
+    run_and_print_results(nil) # Run all
   end
 
   desc 'Print the current configuration file (Uses local config/eslint.json if it exists; uses default config/eslint.json if it does not; optionally force default by passing a parameter)'

--- a/lib/tasks/eslint.rake
+++ b/lib/tasks/eslint.rake
@@ -21,6 +21,7 @@ namespace :eslint do
     run_and_print_results(args[:filename] || 'application')
   end
 
+  desc 'Run ESLint against all project javascript files and report warnings'
   task run_all: :environment do |_, args|
     run_and_print_results(nil) # Run all
   end


### PR DESCRIPTION
This PR adds the following functionality:

- The default run (`rake eslint:run`) now lints all JS asset files (Related to #20)
- If you pass an argument, it can be either a file or a directory, and it can be relative to the project root, or the asset root. (Kinda makes #15 obsolete)
- There is now a progress bar with the severity of linting errors in each file (similar to rubocop)
- The output table displays the source filename (#20)
- Updates the readme to reflect the changes