### PR TITLE
Add ability to run summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ rake eslint:print_config[true]
 ```
 
 You can also retrieve the current eslint.json by visiting `/eslint/eslint.json`
-in your browser. To force retrieval of the default conguration, use
+in your browser. To force retrieval of the default configuration, use
 `/eslint/eslint.json?force_default=true`.
 
 ## Usage
@@ -48,13 +48,49 @@ Or you can run it on a single file. This will analyze `application.js`:
 rake eslint:run
 ```
 
-Or, you can supply a filename to the task, using several different formats, and it will lint just that file. For example, to analyze `app/assets/javascripts/components/utilities.js`, you can run any of the following:
+Or, you can supply a filename to the task, using several different formats, 
+and it will lint just that file. For example, to analyze 
+`app/assets/javascripts/components/utilities.js`, you can run any of the following:
 
 ```sh
 rake eslint:run[components/utilities]
 rake eslint:run[components/utilities.js]
 rake eslint:run[app/assets/javascripts/components/utilities]
 rake eslint:run[app/assets/javascripts/components/utilities.js]
+```
+
+###### Summaries
+
+This will analyze all of the javascript files in the project and return a 
+summary of warnings based on the `group_by` filter parameter:
+
+```sh
+rake eslint:summary[group_by]
+```
+
+Available `group_by` filters: 
+
+- `filename` - displays number of warnings occurred per file
+
+- `warning` - displays number of warnings occurred per assets
+
+
+Or you can get a summary of the warnings on a single file. This will show 
+the summary for `application.js`:
+ 
+```sh
+rake eslint:file_summary
+```
+
+Or, you can supply a filename to the task, using several different formats, 
+and it will lint just that file. For example, to analyze 
+`app/assets/javascripts/components/utilities.js`, you can run any of the following:
+
+```sh
+rake eslint:file_summary[components/utilities]
+rake eslint:file_summary[components/utilities.js]
+rake eslint:file_summary[app/assets/javascripts/components/utilities]
+rake eslint:file_summary[app/assets/javascripts/components/utilities.js]
 ```
 
 ### Web interface

--- a/lib/eslint-rails/text_formatter.rb
+++ b/lib/eslint-rails/text_formatter.rb
@@ -30,8 +30,21 @@ module ESLintRails
           end
         puts colorized_message
       end
-
       puts "#{@warnings.size} warning(s) found."
+    end
+
+    def format_summary
+      max_count_length = max_length_of_attribute(:count)
+      @warnings.each do |warning|
+        message = [
+            warning[:count].to_s.ljust(max_count_length + 1),
+            warning[:item],
+        ].join(' ')
+        puts message
+      end
+      total = @warnings.inject(0) {|sum, hash| sum + hash[:count]}
+      puts '--'
+      puts "#{total} warning(s) found."
     end
 
     private


### PR DESCRIPTION
This PR adds the ability to run a summary on all javascript files from the project and display the number of warnings either grouped by `filename` or by `warning` (type).

I've also included a summary per file where you can see the number of warnings you have on a certain JS/JSX. 

It's a very similar output to what Rubocop does with the `offenses` formatter (http://rubocop.readthedocs.io/en/latest/formatters/#offense-count-formatter).

I think it's a good way of having a glimpse on what to focus on first, when getting your hands on a bigger project.

Here are a few sample outputs of the commands:

### Full summary examples (by `filename` and `warning`)

```sh
$ rake eslint:summary[filename]
517       app/assets/javascripts/lib/rollbar.js
177       app/assets/javascripts/lib/nprogress.js
6         app/assets/javascripts/homepage.js
6         app/assets/javascripts/card_form.js
6         app/assets/javascripts/application.js
6         app/assets/javascripts/board.js
6         app/assets/javascripts/test_bundle.js
--
724 warning(s) found.
```

```sh
$ rake eslint:summary[warning]
121       VariableDeclarator/space-infix-ops
108       Punctuator/comma-spacing
69        Literal/quotes
54        Identifier/no-shadow
45        ReturnStatement/semi-spacing
44        Identifier/no-undef
35        VariableDeclaration/semi
31        VariableDeclarator/no-underscore-dangle
25        IfStatement/curly
23        Identifier/no-use-before-define
22        Program/no-trailing-spaces
19        SequenceExpression/no-sequences
19        ExpressionStatement/no-unused-expressions
13        BinaryExpression/eqeqeq
9         ObjectExpression/key-spacing
8         BinaryExpression/yoda
8         BinaryExpression/space-infix-ops
7         Program/no-empty-class
7         Program/no-extra-strict
7         Punctuator/no-multi-spaces
7         Program/no-empty-label
7         Program/space-return-throw-case
7         Program/no-wrap-func
7         Program/global-strict
5         CatchClause/no-catch-shadow
3         ExpressionStatement/strict
2         ExpressionStatement/semi
2         Identifier/no-unused-vars
2         NewExpression/new-parens
2         NewExpression/new-cap
2         BlockStatement/no-empty
1         EmptyStatement/no-extra-semi
1         MemberExpression/no-console
1         FunctionExpression/consistent-return
1         ForStatement/no-cond-assign
--
724 warning(s) found.
```

### File summary (by default for `application.js`)

```sh
$ rake eslint:file_summary
1         Program/no-empty-class
1         Program/no-empty-label
1         Program/no-extra-strict
1         Program/no-wrap-func
1         Program/global-strict
1         Program/space-return-throw-case
--
6 warning(s) found.
```
