### PR TITLE
Add support for .es6 file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # eslint-rails
 
-Run [ESLint][] against your Rails repo.
+Run [ESLint][] against your Rails repo. The supported javascript file extensions are the following:
+
+- _.js_
+- _.jsx_
+- _.es6_
 
 ## Installation
 

--- a/lib/eslint-rails/runner.rb
+++ b/lib/eslint-rails/runner.rb
@@ -4,7 +4,7 @@ module ESLintRails
   class Runner
     include ActionView::Helpers::JavaScriptHelper
 
-    JAVASCRIPT_EXTENSIONS = %w(.js .jsx)
+    JAVASCRIPT_EXTENSIONS = %w(.js .jsx .es6)
 
     def initialize(file)
       @file = normalize_infile(file)


### PR DESCRIPTION
### Summary

- Add another extension for javascript files to look for (.es6)
- Add list of supported extensions to README

### Purpose

When using ES2015 with asset pipeline on Ruby on Rails and using a transpiler like _babel-transpiler_, the javascript file extension must be _.es6_, which is actually not considered by the gem, so all javascripts files with that extension will be ignored by the linter.