### PR TITLE
Add compatibility with Ruby 2.0

### DIFF
--- a/eslint-rails.gemspec
+++ b/eslint-rails.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.0.0'
+
   spec.add_dependency 'railties', '>= 3.2'
   spec.add_dependency 'execjs'
   spec.add_dependency 'colorize'

--- a/lib/eslint-rails/config.rb
+++ b/lib/eslint-rails/config.rb
@@ -10,7 +10,9 @@ module ESLintRails
     CONFIG_PATH = 'config/eslint.json'
     private_constant :CONFIG_PATH
 
-    def initialize(force_default:)
+    def initialize(force_default: nil)
+      raise(ArgumentError, 'force_default is required') if force_default.nil?
+
       @force_default = force_default
       @custom_file   = Rails.root.join(CONFIG_PATH)
       @default_file  = ESLintRails::Engine.root.join(CONFIG_PATH)


### PR DESCRIPTION
First of all, let me express my gratitude for this gem. 

I've been trying to add a javascript linter to a project I'm working on so we can have some standards, and by far eslint-rails has been the best suited. 

Now, for this project, we need compatibility with Ruby 2.0 (yeah yeah, I know it's not receiving fixes or patches anymore, but we can't upgrade yet.)

The gemspec of eslint-rails doesn't specify a minimum ruby version, but if you try to use the gem with < 2.1, it breaks because of the required keyword arguments that were introduced in 2.1.

This minor change makes the gem compatible with Ruby 2.0 and ensures it's specified on the gemspec.

Thanks!



