### PR TITLE
Fix Rails 5.1; use before_action instead of before_filter

### DIFF
--- a/app/controllers/eslint_controller.rb
+++ b/app/controllers/eslint_controller.rb
@@ -1,6 +1,6 @@
 class EslintController < ActionController::Base
 
-  before_filter :set_filename
+  before_action :set_filename
 
   def show
     @warnings = ESLintRails::Runner.new(@filename).run


### PR DESCRIPTION
`before_filter` is deprecated and was removed in Rails 5.1.

Note: I believe that `before_action` is supported in Rails 4 but not in Rails 3. IMO, if this gem does currently work in Rails 3 (I have no idea if it does), dropping support might not be too bad of an idea given that Rails 3.x has been [officially unsupported](http://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/) since June 2016.