### PR TITLE
Properly handle user supplied nil value in Config.read

### DIFF
--- a/lib/eslint-rails/config.rb
+++ b/lib/eslint-rails/config.rb
@@ -2,6 +2,9 @@ module ESLintRails
   class Config
 
     def self.read(force_default: false)
+      # explicitly checking for nil incase the user passed in a nil value
+      # which would raise an error in #initialize
+      force_default = false if force_default.nil?
       self.new(force_default: force_default).send(:read)
     end
 


### PR DESCRIPTION
The default value of false doesn't override an expicitly passed in nil value, such as when running `bundle exec rake eslint:print_config` without any arguments. As a result you get an unexpected ArgumentError. 

l think this is actually the intended behavior since prior to #32 a nil value wouldn't raise an error in `#initialize` and simply be treated as a "false" value whereas now there is an explicit nil check.

Cheers and thanks for the gem,
Matt
